### PR TITLE
change libchardet url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,4 +31,4 @@
 	url = https://github.com/cyrusimap/wslay
 [submodule "libchardet"]
 	path = libchardet
-	url = git@github.com:cyrusimap/libchardet.git
+	url = https://github.com/cyrusimap/libchardet


### PR DESCRIPTION
Was getting an error with git submodule update. Changing the url seems to have fixed it for me.