### PR TITLE
xapian: just use the autotools we've already got thanks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -106,7 +106,7 @@ if [ ! $ITEM ] || [ $ITEM == xapian ] ; then
   cd xapian
   git clean -f -x -d
   git checkout -B build  # needed so sub-checkouts can find their references
-  ./bootstrap
+  ./bootstrap --download-tools=never
   ./configure --enable-silent-rules --prefix=$PREFIX
   cd xapian-core
   make $MAKEOPTS


### PR DESCRIPTION
Dunno what the ramifications are for others so this is just a PR and not a push.

I really don't see why Xapian needs to be special and download and build its own autotools, and it never bloody works for me anyway, so imo it can eat the same dogfood as everyone else thanks