### PR TITLE
libical: update with libicalvcard bug fixes and fix test runner

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,7 @@ if [ ! $ITEM ] || [ $ITEM == libical ] ; then
         -DLIBICAL_JAVA_BINDINGS=False \
         ..
   make $MAKEOPTS
+  make test
   sudo make install
 )
 fi

--- a/build.sh
+++ b/build.sh
@@ -45,8 +45,8 @@ if [ ! $ITEM ] || [ $ITEM == libical ] ; then
         -DLIBICAL_JAVA_BINDINGS=False \
         ..
   make $MAKEOPTS
-  make test
   sudo make install
+  make test # libical test requires libical to be installed
 )
 fi
 


### PR DESCRIPTION
This updates the cyruslibs libical fork to include a couple of bug fixes in libicalvcard: please check: https://github.com/cyrusimap/libical/compare/cyruslibs-fastmail-v70...cyrusimap:libical:cyrus?expand=1
We will try to merge these in libical upstream later.

It also changes the build script to run libical tests *after* we installed libical. Note that latest tagged cyruslibs did not run any libical tests at all, but a commit after that tag and before this pull request added running libical unit tests. It turns out that at least some of libical tests link against the installed libical version, not the one that just is being built and tested. We will attempt fixing this in libical's build config, but until then will run tests after install (which is still better than not running tests at all).